### PR TITLE
Add post: developing on the go with Tailscale, Termux, and swarm-forge

### DIFF
--- a/app/tag-data.json
+++ b/app/tag-data.json
@@ -3,5 +3,9 @@
   "csv": 1,
   "cli": 1,
   "csvlens": 1,
-  "productivity": 1
+  "productivity": 2,
+  "tailscale": 1,
+  "termux": 1,
+  "ssh": 1,
+  "swarmforge": 1
 }

--- a/data/blog/tailscale-swarmforge-on-the-go.mdx
+++ b/data/blog/tailscale-swarmforge-on-the-go.mdx
@@ -1,0 +1,49 @@
+---
+title: Developing on the go with Tailscale, Termux, and a tmux Dashboard
+date: '2026-07-03'
+tags: ['tailscale', 'termux', 'ssh', 'swarmforge', 'productivity']
+draft: false
+summary: My development workflow runs almost entirely through swarm-forge, which normally means sitting at my desk to kick off specs, answer clarifying questions, and approve commands. Tailscale and Termux let me SSH in from my phone and unblock that flow from anywhere.
+---
+
+Most of my development work now runs through [swarm-forge](https://github.com/garrelj1/swarm-forge), a tool I use to coordinate several AI agents on a task. It's a good workflow, but it has one dependency I didn't love: it assumes I'm sitting at my development machine. Kicking off spec design, answering the clarifying questions an agent poses, and approving or denying the commands it wants to run all happen at that one keyboard. Step away, and the whole pipeline stalls until I get back to it.
+
+Tailscale and Termux fixed that. Now I can SSH into my main dev machine from my phone, from wherever I am, and unblock the flow without walking back to my desk.
+
+## The problem: presence-gated progress
+
+The friction wasn't the AI agents themselves. It was that three specific moments in the loop required me physically at the machine:
+
+- Kicking off a new spec design.
+- Answering a clarifying question the agent needed resolved before it could keep going.
+- Approving or denying a command before it executed.
+
+Any one of those could show up while I was away from the desk for any reason. The work didn't fail. It just sat there, waiting on me.
+
+## What Tailscale actually does
+
+[Tailscale](https://tailscale.com/kb/1151/what-is-tailscale) describes itself as "a Zero Trust identity-based connectivity platform," built on WireGuard, "the open source WireGuard protocol," which it calls "a state-of-the-art VPN protocol known for its security and performance." It creates a peer-to-peer mesh network, what Tailscale calls a tailnet, so "each device is connected to the other directly." Tailscale's docs also note that this works "across firewalls and Network Address Translation (NAT) without requiring port forwarding or complex firewall rules," which is the part that mattered most for me: no router configuration, no exposed ports on my home network, just my devices finding each other.
+
+I installed it on my dev machine and on my phone, joined both to the same tailnet, and that was effectively the entire setup. My phone can now reach my desktop the same way it reaches any other device on the tailnet, regardless of which network either one is actually sitting on.
+
+## Termux: an SSH client that lives on my phone
+
+[Termux](https://termux.dev/en/) is, in its own description, "an Android terminal emulator and Linux environment app that works directly with no rooting or setup required." That matters here for one specific reason: it ships the ability to "access remote servers using the ssh client from OpenSSH." Between Tailscale handling the network path and Termux handling the terminal and SSH client, I have everything I need to reach my dev machine from a phone in my pocket.
+
+The combination is simple in practice. Tailscale gets my phone and my desktop onto the same private network no matter where either one physically is. Termux gives me a real terminal and a real `ssh` binary to use once I'm there.
+
+## Closing the loop: a tmux dashboard for swarm-forge
+
+SSH access alone gets me a shell, but swarm-forge's loop involves watching what the Claude CLI is doing and responding to it in real time, not just running one command and disconnecting. To make that workable from a phone screen, I built a tmux dashboard, kept at `swarmforge/scripts/` in the swarm-forge repo, that lets me view and interact directly with the Claude CLI's input and output over that SSH session.
+
+That's the piece that turns "I can technically SSH in" into "I can actually keep the swarm moving." I open Termux, SSH to my dev machine over the tailnet, attach to the dashboard, and I'm looking at the same input and output I'd see sitting at my desk. I can answer a clarifying question or approve a command from my phone exactly as I would from my keyboard.
+
+## Where this leaves me
+
+None of this changes how swarm-forge itself works. It changes where I'm allowed to be when it needs me. The presence requirement used to mean real gaps in the workflow: an agent finishes a task, needs a decision, and waits because I'm not at my desk. Now the same moment gets handled from a phone, and the swarm keeps moving.
+
+## Sources
+
+- [What is Tailscale? – Tailscale Docs](https://tailscale.com/kb/1151/what-is-tailscale)
+- [Termux – Official Site](https://termux.dev/en/)
+- [swarm-forge](https://github.com/garrelj1/swarm-forge)

--- a/data/blog/tailscale-swarmforge-on-the-go.mdx
+++ b/data/blog/tailscale-swarmforge-on-the-go.mdx
@@ -42,6 +42,8 @@ That's the piece that turns "I can technically SSH in" into "I can actually keep
 
 None of this changes how swarm-forge itself works. It changes where I'm allowed to be when it needs me. The presence requirement used to mean real gaps in the workflow: an agent finishes a task, needs a decision, and waits because I'm not at my desk. Now the same moment gets handled from a phone, and the swarm keeps moving.
 
+It's a narrow fix, but it points at a broader pattern: a workflow only counts as automated if it doesn't quietly depend on one person being at one machine. Finding that gate and removing it is most of what [the workflow and automation work I do at Garrell Tech Solutions](/) actually looks like.
+
 ## Sources
 
 - [What is Tailscale? – Tailscale Docs](https://tailscale.com/kb/1151/what-is-tailscale)


### PR DESCRIPTION
## Summary

Combined tech + project update post: how Tailscale (mesh VPN) and Termux (Android terminal/SSH client) let Jeremy unblock his swarm-forge development workflow while away from his dev machine, including a tmux dashboard he built for viewing/interacting with the Claude CLI over SSH.

**Note:** the brief described swarm-forge as a private repo; `gh repo view` shows it's actually `PUBLIC`. Flagged during the run; the disclosure whitelist was still honored regardless.

## Claims audit

| Claim | Type | Source | Verdict |
| ----- | ---- | ------ | ------- |
| Dev workflow runs almost entirely through swarm-forge | Experience | Brief | Supported |
| Must be at dev machine for spec design, clarifying Qs, command approval | Experience | Brief | Supported |
| Tailscale + Termux let him SSH in from his phone from anywhere | Experience | Brief | Supported |
| swarm-forge is "a tool ... for coordinating several AI agents" | Sourced | `gh repo view garrelj1/swarm-forge` description field | Supported |
| Tailscale is a "Zero Trust identity-based connectivity platform" built on WireGuard | Sourced | tailscale.com/kb/1151/what-is-tailscale | Supported |
| Tailscale creates a peer-to-peer mesh network ("tailnet"), devices connect directly | Sourced | tailscale.com/kb/1151/what-is-tailscale | Supported |
| Works across firewalls/NAT without port forwarding | Sourced | tailscale.com/kb/1151/what-is-tailscale | Supported |
| Termux is "an Android terminal emulator and Linux environment app," no root required | Sourced | termux.dev/en | Supported |
| Termux ships an SSH client via OpenSSH | Sourced | termux.dev/en | Supported |
| tmux dashboard exists at swarmforge/scripts/, lets him view/interact with Claude CLI I/O over SSH | Experience + Sourced (existence only) | Brief + `gh api contents/swarmforge/scripts` confirms a script exists at that path | Supported (script's actual filename/contents not disclosed) |

## Disclosures (update mode)

- That swarm-forge is Jeremy's project and roughly what it does (coordinating multiple AI agents) — sourced from the repo's own public description.
- That a tmux dashboard script exists under `swarmforge/scripts/` in that repo, and its purpose (viewing/interacting with the Claude CLI's input/output over SSH) — purpose per Jeremy's brief, existence confirmed via `gh`.
- General shape of the workflow gate (spec design kickoff, clarifying questions, command approval requiring his presence).

Not disclosed: the dashboard script's filename, its code/contents, any other script in that directory, or any other repo structure/detail.

## Cut or rewritten during audit

- Removed a fabricated personal anecdote ("making coffee, picking up my kid") not present in the brief.
- Removed an invented "waits an hour" time figure not present in the brief.
- Reworded the Tailscale intro sentence, which had substituted an unsourced paraphrase ("connectivity platform built on WireGuard") for Tailscale's actual self-description; now quotes it directly.
- Removed an unsupported "instead of routing through a central VPN server" comparison with no matching evidence entry.

## Also in this diff

- `app/tag-data.json`: auto-updated tag index (new tags: tailscale, termux, ssh, swarmforge).
