### PR TITLE
Add blog post: winning government IT contracts in Florida, Broward, and Coral Springs

### DIFF
--- a/data/blog/government-it-contracts-south-florida.mdx
+++ b/data/blog/government-it-contracts-south-florida.mdx
@@ -1,0 +1,77 @@
+---
+title: How Small IT Firms Can Win Government Software Contracts in Florida, Broward County, and Coral Springs
+date: '2026-07-16'
+tags: ['government-contracts', 'small-business', 'florida', 'broward-county', 'procurement']
+draft: false
+summary: A step-by-step guide for South Florida IT and software firms to register and get certified for government contracts at the state, Broward County, and Coral Springs level.
+---
+
+Every year, the State of Florida, Broward County, and the City of Coral Springs all pay outside firms to build and support software. Some of that work goes to national systems integrators. A lot of it, especially the smaller task orders and staff augmentation gigs, goes to firms nobody outside procurement offices has heard of. If you run a small IT consultancy or software shop in South Florida and have never sold to government, that second category is closer than it looks, and there's a real head start built into being local.
+
+This is a walkthrough of how to register, get certified, and start seeing the work at three levels of government: the state, the county, and your own city. None of it requires a lobbyist or a bid consultant. It requires paperwork, patience, and knowing where to look.
+
+## Why government work is worth the paperwork
+
+Agencies run structured programs that exist specifically to steer work toward small businesses, local vendors, and historically underutilized firms, so a small shop isn't just competing against the same handful of national contractors on every deal. Some solicitations are set aside, meaning only certified small or local businesses are even allowed to bid, and Broward County in particular requires a chunk of contract value go to certified local firms regardless of who wins the prime contract. None of that shows up if you're not registered anywhere to see it.
+
+## Level 1: State of Florida
+
+Start with the [MyFloridaMarketPlace Vendor Information Portal (VIP)](https://vendor.myfloridamarketplace.com/register). This is the master vendor record for the entire state: your legal business name, Federal Tax ID, tax filing name, business location, and the commodity codes describing what you sell. Commodity codes matter more than they sound like they should, because agencies filter by them when deciding who gets notified about a new solicitation, the formal term for a posted bid or RFP (Request for Proposal). Pick every IT-related code that applies (custom software development, programming services, IT consulting, data processing) or you'll miss opportunities that were never hidden, just filed under a code you didn't select.
+
+Alongside VIP registration, file a [Florida Substitute Form W-9](https://flvendor.myfloridacfo.com/casappsp/cw9hform.shtml) with the Department of Financial Services. It's how the state determines whether payments to you are reportable and whether federal withholding applies, and it's a separate system from VIP, so don't assume one registration covers both.
+
+Once you're registered, solicitations live on the [Vendor Bid System (VBS)](https://www.dms.myflorida.com/business_operations/state_purchasing/vendor_bid_system_vbs), where agencies post competitive solicitations, intended awards, and single-source purchase notices, searchable by agency and commodity code. For IT specifically, look at the [Information Technology Staff Augmentation Services state term contract](https://www.dms.myflorida.com/business_operations/state_purchasing/state_contracts_and_agreements/state_term_contract/information_technology_staff_augmentation), the vehicle the Department of Management Services (DMS) manages so agencies can bring on contract developers and IT talent without running a fresh competitive process for every hire. You get on it when DMS periodically re-solicits the contract, so it's worth tracking rather than assuming the window is permanently closed. One-off IT projects that don't fit that vehicle still show up as regular postings on VBS.
+
+If your firm is woman-, veteran-, or minority-owned, get certified for free through the [Florida Office of Supplier Diversity (OSD)](https://www.dms.myflorida.com/agency_administration/office_of_supplier_diversity_osd/get_certified). It puts you in the state's vendor directory and gives you visibility state agencies specifically look for when they're trying to meet diversity goals in their sourcing.
+
+## Level 2: Broward County
+
+Broward County runs its own procurement system, [BPRO, powered by Bonfire](https://www.broward.org/Purchasing/Pages/Default.aspx). Registering there, separate from anything at the state level, is what lets you view, download, and respond to county solicitations. It's free, and the county explicitly does not require paying for "leads."
+
+The certification layer here has real teeth. The county's [Office of Economic and Small Business Development (OESBD)](https://www.broward.org/EconDev/SmallBusiness/pages/certification.aspx), reachable at 954-357-6400, certifies firms as Small Business Enterprise (SBE), County Business Enterprise (CBE), or under two federal categories (DBE and Airport Concession DBE). Projects with small business opportunities require that at least 25% of contract value go to certified CBE firms, and when the county sets an SBE reserve on a project, only SBE-certified firms are allowed to bid on it at all, not just given a preference. That's a materially different thing than a scoring bonus.
+
+Eligibility for SBE and CBE both require a [Broward Business Tax Receipt and a physical address inside Broward County](https://www.broward.org/EconDev/Pages/localcertificationprograms.aspx), not a P.O. box or virtual office, since OESBD does a site visit to confirm it. You also need at least a year in business before applying, and SBE specifically caps at 15 permanent full-time employees.
+
+Two other Broward buyers are worth registering with separately, since they run independent procurement processes from the county government itself: [Broward County Public Schools](https://www.browardschools.com/bcps-departments/economic-development-opportunities-compliance-edoc/smwbe-certification) offers its own free S/M/WBE certification through an Ariba-based portal, with a Tri-County Reciprocal option if you're already certified with Miami-Dade, Broward, or Palm Beach County government or schools, and Broward Health recognizes small business vendors who register in its VRS system and upload a valid federal, state, or local certification.
+
+## Level 3: City of Coral Springs
+
+Coral Springs has been moving off paper-based bidding onto [OpenGov](https://www.einpresswire.com/article/819733847/city-of-coral-springs-fl-invests-in-procurement-modernization-with-opengov) for electronic bidding and vendor management, and the city's solicitations are also distributed through [DemandStar](https://www.demandstar.com/app/agencies/florida/city-of-coral-springs/procurement-opportunities/4d3fecc6-6f5a-4285-a813-82546ac5541b/). Register on both during the transition rather than betting on which one will carry every posting. The city's Purchasing Division is located at 9500 W. Sample Road, Coral Springs, FL 33065, if you ever need to follow up in person or by phone.
+
+## Your first 30 days
+
+In rough order:
+
+1. Register in MyFloridaMarketPlace VIP and select every relevant IT commodity code.
+2. File your Florida Substitute Form W-9 with the Department of Financial Services.
+3. Register in Broward County's BPRO (Bonfire) system.
+4. Call OESBD at 954-357-6400 and start your SBE/CBE application if you meet the criteria (Broward Business Tax Receipt, physical Broward address, one year in business, 15 or fewer employees for SBE).
+5. Register on Coral Springs' OpenGov portal and on DemandStar.
+6. Apply for Florida OSD certification if you qualify as woman-, veteran-, or minority-owned.
+7. Set up watches on VBS and BPRO for your commodity codes so new postings come to you instead of you searching for them.
+
+None of this paperwork is single-purpose. Broward SBE/CBE, Florida OSD certification, and federal SAM.gov small business registration are complementary credentials, worth holding all three if you plan to bid at every level, even though none of them by itself opens the door to another level's portal. It's also worth showing up in person: Broward hosts vendor matchmaking events and two annual vendor conferences, and agencies frequently quote smaller IT jobs directly to vendors they already know, before a solicitation is ever posted. If you want help navigating any of it without paying a consultant, the [Florida SBDC at FAU](https://www.fau.edu/sbdc/government-contracting/) offers free one-on-one government contracting consulting to Broward businesses.
+
+## The local advantage is real, if you use it
+
+None of these programs are secret. They're just spread across three separate systems with three separate registration processes, and that's usually enough to stop a small shop before it starts. Being based in Coral Springs, inside Broward County, inside Florida, means you already qualify for local preference in ways a national firm doesn't. The paperwork is the only thing standing between that advantage and an actual contract.
+
+We're working through this same registration and certification process right now at [Garrell Tech Solutions](/), as we look for federal, state, and local government work of our own. If you want to compare notes on where to start for your specific business, [schedule a free consultation](https://calendly.com/jeremy-garrell/30min) and we'll walk through it together.
+
+One last note: procurement portals, certification rules, and contact details change. Confirm current requirements directly on [dms.myflorida.com](https://www.dms.myflorida.com/), [broward.org/Purchasing](https://www.broward.org/Purchasing/Pages/Default.aspx), [broward.org/EconDev](https://www.broward.org/EconDev/SmallBusiness/pages/certification.aspx), and [coralsprings.gov](https://www.coralsprings.gov/Government/Departments/Purchasing) before you rely on anything above.
+
+## Sources
+
+- [MyFloridaMarketPlace Vendor Information Portal](https://vendor.myfloridamarketplace.com/register)
+- [Florida Substitute Form W-9](https://flvendor.myfloridacfo.com/casappsp/cw9hform.shtml)
+- [Florida Vendor Bid System (VBS)](https://www.dms.myflorida.com/business_operations/state_purchasing/vendor_bid_system_vbs)
+- [IT Staff Augmentation Services state term contract](https://www.dms.myflorida.com/business_operations/state_purchasing/state_contracts_and_agreements/state_term_contract/information_technology_staff_augmentation)
+- [Florida Office of Supplier Diversity](https://www.dms.myflorida.com/agency_administration/office_of_supplier_diversity_osd/get_certified)
+- [Broward County Purchasing Division / BPRO](https://www.broward.org/Purchasing/Pages/Default.aspx)
+- [Broward County Small Business Certification (OESBD)](https://www.broward.org/EconDev/SmallBusiness/pages/certification.aspx)
+- [Broward County Local Certification Program eligibility](https://www.broward.org/EconDev/Pages/localcertificationprograms.aspx)
+- [Broward County Public Schools S/M/WBE Certification](https://www.browardschools.com/bcps-departments/economic-development-opportunities-compliance-edoc/smwbe-certification)
+- [Broward Health Small Business Vendor Certification](https://www.browardhealth.org/vendor/small-business-vendor-certification)
+- [City of Coral Springs procurement modernization with OpenGov](https://www.einpresswire.com/article/819733847/city-of-coral-springs-fl-invests-in-procurement-modernization-with-opengov)
+- [City of Coral Springs on DemandStar](https://www.demandstar.com/app/agencies/florida/city-of-coral-springs/procurement-opportunities/4d3fecc6-6f5a-4285-a813-82546ac5541b/)
+- [Florida SBDC at FAU: Government Contracting](https://www.fau.edu/sbdc/government-contracting/)


### PR DESCRIPTION
## Summary

Step-by-step guide for small South Florida IT/software firms on registering and getting certified to sell to government at three levels: the State of Florida (MyFloridaMarketPlace VIP, Substitute W-9, VBS, IT Staff Augmentation state term contract, OSD certification), Broward County (BPRO/Bonfire, OESBD SBE/CBE certification, school board, Broward Health), and the City of Coral Springs (OpenGov, DemandStar). Ends with a "first 30 days" checklist and a single CTA to schedule a consultation with Garrell Tech Solutions.

No dedicated services page exists on the site yet, so the internal link points to the homepage (`/`) per Jeremy's direction; the front-end overhaul in PR#9 may supersede this later. The CTA links directly to https://calendly.com/jeremy-garrell/30min since there's no scheduler component on the site.

## Claims audit

| Claim | Type | Source | Verdict |
| ----- | ---- | ------ | ------- |
| MyFloridaMarketPlace VIP registration fields, commodity codes | sourced | vendor.myfloridamarketplace.com + floridadisaster.org vendor fact sheet | supported |
| Florida Substitute Form W-9 process | sourced | flvendor.myfloridacfo.com | supported |
| Vendor Bid System (VBS) contents | sourced | dms.myflorida.com + djj.state.fl.us | supported |
| IT Staff Augmentation state term contract, DMS-managed, join via re-solicitation | sourced | dms.myflorida.com + DMS vendor FAQ PDF | supported |
| Florida OSD free certification | sourced | dms.myflorida.com OSD page | supported |
| BPRO/Bonfire registration, free | sourced | broward.org/Purchasing | supported |
| OESBD SBE/CBE/DBE/ACDBE, 25% CBE allocation, SBE reserve, phone | sourced | broward.org/EconDev/SmallBusiness | supported |
| SBE/CBE eligibility (tax receipt, physical address, 1yr, 15 employees, site visit) | sourced | broward.org/EconDev local certification programs page | supported |
| BCPS free S/M/WBE via Ariba + Tri-County Reciprocal | sourced | browardschools.com | supported |
| Broward Health VRS certification upload | sourced | browardhealth.org | supported |
| Coral Springs OpenGov adoption | sourced (tier 2, vendor press release) | einpresswire.com | supported |
| Coral Springs on DemandStar | sourced | demandstar.com agency page | supported |
| Purchasing Division address | sourced | corroborated via multiple independent listings after primary site returned 403 | supported |
| Florida SBDC at FAU free consulting | sourced | fau.edu/sbdc/government-contracting | supported |
| Matchmaking events/vendor conferences, direct-quote relationships, certifications stacking | sourced from brief | Jeremy's brief | supported |
| "We're working through this same process ourselves... as we look for federal, state, and local government work" | experience | Jeremy stated directly in conversation that GTS is currently seeking this work | supported |

## Cut or rewritten during audit

- Cut an invented "same five national contractors" figure — no source for the specific number.
- Cut "government IT budgets don't disappear in a downturn" — unsourced economic generalization.
- Rewrote "we've gone through this registration and certification process" (implying completed track record) to "we're working through this same process right now" — matches what Jeremy actually said, not a fabricated completed history.
- Rewrote the SAM.gov "covers all three levels of government" line — overstated what federal SAM.gov registration actually grants; reworded to describe the three certifications as complementary rather than implying SAM.gov unlocks state/county access.
- Cut "which is exactly why most small IT shops never get past the first page of a government RFP" — unsourced.
- Dropped an unverified `broward.org/EconDev/Pages/procurement-opportunities.aspx` link in the closing note in favor of a URL actually fetched this run.
- Dropped an unconfirmed "City Hall" label on the Coral Springs Purchasing Division address, keeping just the verified street address.