### PR TITLE
Optimize tailscale/termux post for SEO and GEO

### DIFF
--- a/data/blog/tailscale-swarmforge-on-the-go.mdx
+++ b/data/blog/tailscale-swarmforge-on-the-go.mdx
@@ -1,51 +1,68 @@
 ---
-title: Developing on the go with Tailscale, Termux, and a tmux Dashboard
+title: Developing on the go with Tailscale, Termux, and tmux
 date: '2026-07-03'
+lastmod: '2026-07-20'
 tags: ['tailscale', 'termux', 'ssh', 'swarmforge', 'productivity']
 draft: false
-summary: My development workflow runs almost entirely through swarm-forge, which normally means sitting at my desk to kick off specs, answer clarifying questions, and approve commands. Tailscale and Termux let me SSH in from my phone and unblock that flow from anywhere.
+summary: Tailscale and Termux let me SSH into my dev machine from my phone, so a stalled AI agent doesn't have to wait until I'm back at my desk.
 ---
 
-Most of my development work now runs through [swarm-forge](https://github.com/garrelj1/swarm-forge), a tool I use to coordinate several AI agents on a task. It's a good workflow, but it has one dependency I didn't love: it assumes I'm sitting at my development machine. Kicking off spec design, answering the clarifying questions an agent poses, and approving or denying the commands it wants to run all happen at that one keyboard. Step away, and the whole pipeline stalls until I get back to it.
+Tailscale and Termux let me SSH into my dev machine from my phone, from anywhere, over an encrypted peer-to-peer connection with no port forwarding or router configuration required. That solves a real problem: my development work runs through [swarm-forge](https://github.com/garrelj1/swarm-forge), a tool I use to coordinate several AI agents on a task, and its workflow used to stall completely whenever I stepped away from my desk. Now a phone in my pocket is enough to keep the agents moving, wherever I am.
 
-Tailscale and Termux fixed that. Now I can SSH into my main dev machine from my phone, from wherever I am, and unblock the flow without walking back to my desk.
+## Why did swarm-forge need me at my desk?
 
-## The problem: presence-gated progress
-
-The friction wasn't the AI agents themselves. It was that three specific moments in the loop required me physically at the machine:
+swarm-forge is a good workflow, but it had one dependency I didn't love: it assumed I was sitting at my development machine. Three specific moments in the loop required that:
 
 - Kicking off a new spec design.
 - Answering a clarifying question the agent needed resolved before it could keep going.
 - Approving or denying a command before it executed.
 
-Any one of those could show up while I was away from the desk for any reason. The work didn't fail. It just sat there, waiting on me.
+Any one of those could come up while I was away from the desk for any reason. The work didn't fail. It just sat there, waiting on me.
 
-## What Tailscale actually does
+## What does Tailscale actually do?
 
-[Tailscale](https://tailscale.com/kb/1151/what-is-tailscale) describes itself as "a Zero Trust identity-based connectivity platform," built on WireGuard, "the open source WireGuard protocol," which it calls "a state-of-the-art VPN protocol known for its security and performance." It creates a peer-to-peer mesh network, what Tailscale calls a tailnet, so "each device is connected to the other directly." Tailscale's docs also note that this works "across firewalls and Network Address Translation (NAT) without requiring port forwarding or complex firewall rules," which is the part that mattered most for me: no router configuration, no exposed ports on my home network, just my devices finding each other.
+[Tailscale](https://tailscale.com/kb/1151/what-is-tailscale) is "a Zero Trust identity-based connectivity platform that replaces your legacy VPN, SASE, and PAM." It creates "a peer-to-peer mesh network (known as a tailnet)" and "enables encrypted point-to-point connections using the open source WireGuard protocol." The part that mattered most for me: connections between devices on the tailnet "work seamlessly across firewalls and Network Address Translation (NAT) without requiring port forwarding or complex firewall rules" — no router configuration, no exposed ports on my home network, just my devices finding each other.
 
 I installed it on my dev machine and on my phone, joined both to the same tailnet, and that was effectively the entire setup. My phone can now reach my desktop the same way it reaches any other device on the tailnet, regardless of which network either one is actually sitting on.
 
-## Termux: an SSH client that lives on my phone
+## What is Termux, and why do I need it?
 
-[Termux](https://termux.dev/en/) is, in its own description, "an Android terminal emulator and Linux environment app that works directly with no rooting or setup required." That matters here for one specific reason: it ships the ability to "access remote servers using the ssh client from OpenSSH." Between Tailscale handling the network path and Termux handling the terminal and SSH client, I have everything I need to reach my dev machine from a phone in my pocket.
+[Termux](https://termux.dev/en/) describes itself as "an Android terminal emulator and Linux environment app that works directly with no rooting or setup required." That matters here for one specific reason: it ships the ability to "access remote servers using the ssh client from OpenSSH." Between Tailscale handling the network path and Termux handling the terminal and SSH client, I have everything I need to reach my dev machine from a phone in my pocket.
 
 The combination is simple in practice. Tailscale gets my phone and my desktop onto the same private network no matter where either one physically is. Termux gives me a real terminal and a real `ssh` binary to use once I'm there.
 
-## Closing the loop: a tmux dashboard for swarm-forge
+## How do I actually interact with swarm-forge over SSH?
 
 SSH access alone gets me a shell, but swarm-forge's loop involves watching what the Claude CLI is doing and responding to it in real time, not just running one command and disconnecting. To make that workable from a phone screen, I built a tmux dashboard, kept at `swarmforge/scripts/` in the swarm-forge repo, that lets me view and interact directly with the Claude CLI's input and output over that SSH session.
 
 That's the piece that turns "I can technically SSH in" into "I can actually keep the swarm moving." I open Termux, SSH to my dev machine over the tailnet, attach to the dashboard, and I'm looking at the same input and output I'd see sitting at my desk. I can answer a clarifying question or approve a command from my phone exactly as I would from my keyboard.
 
-## Where this leaves me
+## Does this change how swarm-forge works?
 
-None of this changes how swarm-forge itself works. It changes where I'm allowed to be when it needs me. The presence requirement used to mean real gaps in the workflow: an agent finishes a task, needs a decision, and waits because I'm not at my desk. Now the same moment gets handled from a phone, and the swarm keeps moving.
+No. It changes where I'm allowed to be when it needs me. The presence requirement used to mean real gaps in the workflow: an agent finishes a task, needs a decision, and waits because I'm not at my desk. Now the same moment gets handled from a phone, and the swarm keeps moving.
 
 It's a narrow fix, but it points at a broader pattern: a workflow only counts as automated if it doesn't quietly depend on one person being at one machine. Finding that gate and removing it is most of what [the workflow and automation work I do at Garrell Tech Solutions](/) actually looks like.
+
+## FAQ
+
+**Is Tailscale free for a personal setup like this?**
+Yes. Tailscale's Personal plan is free, supports up to 6 users and unlimited devices, and includes basic Tailscale SSH for up to 5 hosts — enough for a single dev machine and phone.
+
+**Do I need to root my Android phone to use Termux?**
+No. Termux "works directly with no rooting or setup required."
+
+**Where do I install Termux, since it's not on the Google Play Store?**
+From [F-Droid](https://f-droid.org/en/packages/com.termux/) or directly from [GitHub](https://github.com/termux/termux-app#github) — those are the two sources Termux's own site points to.
+
+**Does this expose my dev machine to the public internet?**
+No. Tailscale connections work "across firewalls and Network Address Translation (NAT) without requiring port forwarding or complex firewall rules," so there's nothing to open on my router or expose to the open internet.
+
+**Can I use this same setup on iPhone instead of Android?**
+Not with Termux — it's an Android-only app.
 
 ## Sources
 
 - [What is Tailscale? – Tailscale Docs](https://tailscale.com/kb/1151/what-is-tailscale)
+- [Tailscale Pricing](https://tailscale.com/pricing)
 - [Termux – Official Site](https://termux.dev/en/)
 - [swarm-forge](https://github.com/garrelj1/swarm-forge)


### PR DESCRIPTION
## Summary

Retrofits the Tailscale/Termux/tmux post to the SEO + GEO bar now baked into write-blog, using the new optimize-blog skill. This is the first real run of that skill.

## Gaps closed

| Gap | Before | After |
| --- | ------ | ----- |
| Title over 60 chars | 65 chars | 53 chars |
| Meta description way over 155 chars | ~262 chars | 136 chars |
| No `lastmod` | absent | `2026-07-20` |
| Not answer-first | Answer landed in paragraph 2, after scene-setting | Post now opens with a 3-sentence self-contained answer |
| Headings weren't questions | "The problem: presence-gated progress," "Where this leaves me," etc. | Reworded as real questions a reader would ask |
| No FAQ | absent | Added, 5 Q&As |
| No comparison table | n/a | Skipped by request — the post is one specific workflow, not a buyer's-guide comparison |
| No focus keyword on record | predates that step (added 2026-07-05; post is dated 2026-07-03) | "SSH into your dev machine from your phone with Tailscale" + related: Tailscale mesh VPN, Termux SSH, tmux dashboard, remote development, WireGuard |

## Facts re-verified

| Claim | Prior value | Current value | Source |
| ----- | ----------- | -------------- | ------ |
| WireGuard description | Quoted Tailscale's docs calling WireGuard "a state-of-the-art VPN protocol known for its security and performance" | That exact phrase no longer appears on the live page; docs now describe it functionally instead | tailscale.com/kb/1151/what-is-tailscale |
| Tailscale mesh/NAT-traversal claims | — | Unchanged, still verbatim on the live page | tailscale.com/kb/1151/what-is-tailscale |
| Termux rooting/SSH-client claims | — | Unchanged | termux.dev/en |
| Tailscale Personal plan pricing (new, for FAQ) | — | Free, up to 6 users, unlimited devices, basic SSH up to 5 hosts | tailscale.com/pricing |
| Termux install sources (new, for FAQ) | — | F-Droid and GitHub; Google Play not offered | termux.dev/en, github.com/termux/termux-app |
| swarm-forge repo | — | Still public, description matches | github.com/garrelj1/swarm-forge |

## Claims audit

A fresh subagent audited the retrofitted post against the evidence file and the original post as ground truth. It flagged one unsupported claim (an FAQ line speculating about an "iOS equivalent" with no backing source) and one link worth double-checking (an F-Droid link that pointed to a GitHub anchor instead of the real store URL). Both fixed below.

## Cut or rewritten during audit

- Cut: "An iOS equivalent would need a different terminal/SSH client that can join the same tailnet" — no source backed this claim; the FAQ answer now just states Termux is Android-only.
- Fixed: F-Droid link now points to https://f-droid.org/en/packages/com.termux/ instead of a GitHub anchor.

## Notes

- File path and `date` are untouched, per the skill's hard rules — the live URL doesn't move and publish history isn't rewritten.
- `yarn build` regenerated `app/tag-data.json` with unrelated tag counts from another post that had drifted out of date (missing "government-contracts," "florida," etc. from what looks like an earlier post's tags never being regenerated). Reverted that from this diff since it's unrelated to this change — worth a separate look whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)