### PR TITLE
Optimize csvlens post for SEO and GEO

### DIFF
--- a/data/blog/csvlens-default-csv-app.mdx
+++ b/data/blog/csvlens-default-csv-app.mdx
@@ -1,40 +1,35 @@
 ---
-title: Seamless CSV Viewing on Linux with csvlens
+title: How to Set csvlens as Your Default CSV Viewer on Ubuntu
 date: '2025-07-11'
+lastmod: '2026-07-20'
 tags: ['linux', 'csv', 'cli', 'csvlens', 'productivity']
-draft: false 
-summary: Learn how to set up your Ubuntu system to automatically open CSV files in the terminal using csvlens, a powerful CLI tool that fills a gap in Linux software for efficient data viewing.
+draft: false
+summary: csvlens is a command-line CSV viewer, like less but made for CSV. Here's how to make it your default app for opening .csv files on Ubuntu.
 ---
 
-If you're a Linux user who frequently works with CSV files, you've likely experienced a common frustration: the often-limited software options for quickly viewing and navigating large datasets. While Windows and macOS might boast feature-rich spreadsheet applications, Linux users often find themselves resorting to clunky editors or full-blown office suites for a simple peek at a CSV. This can be slow, resource-intensive, and frankly, overkill for a quick look.
+csvlens is a command-line CSV viewer, described in its own README as "like `less` but made for CSV." If you've already installed it with `cargo install csvlens`, you can make it the default app that opens whenever you double-click a `.csv` file on Ubuntu, in five steps: find the executable, create a `.desktop` entry, register it with `xdg-mime`, refresh the MIME database, and test it.
 
-This is where `csvlens` shines – a fantastic command-line interface (CLI) tool that brings powerful CSV viewing capabilities right into your terminal, filling a crucial gap in the Linux software ecosystem. If you've already installed `csvlens` via `cargo install`, you're just a few steps away from making it your default CSV viewer. This post will guide you through setting up your Ubuntu system to automatically open CSV files with `csvlens` when you click them, providing a much-needed, seamless terminal-based solution.
+Windows and macOS have feature-rich spreadsheet apps built in. Linux often leaves you choosing between a clunky text editor and a full office suite just to glance at a CSV. csvlens fills that gap directly in the terminal, and once it's installed, wiring it up as your default viewer only takes a few steps.
 
------
+## Where is the csvlens executable after installing it with cargo?
 
-## Step 1: Find Your `csvlens` Executable
-
-First things first, we need to locate the `csvlens` executable. Since you installed it with `cargo install`, it's most likely in your Cargo bin directory, usually `~/.cargo/bin/`. To confirm the exact path, open your terminal and run:
+Since you installed it with `cargo install`, the binary is most likely in your Cargo bin directory, usually `~/.cargo/bin/`. Confirm the exact path:
 
 ```bash
 which csvlens
 ```
 
-You'll get an output similar to `/home/yourusername/.cargo/bin/csvlens`. Make sure to **note this full path down**, as you'll need it in the next step.
+This returns something like `/home/yourusername/.cargo/bin/csvlens`. Note the full path — you'll need it in the next step.
 
------
+## How do I create a desktop entry so Ubuntu knows how to launch csvlens?
 
-## Step 2: Create a Desktop Entry for `csvlens`
-
-To tell your graphical environment how to launch `csvlens`, we'll create a `.desktop` file. This file acts as a shortcut and contains instructions for opening your application.
-
-Open a text editor and create a new file named **`csvlens.desktop`** in the `~/.local/share/applications/` directory:
+A `.desktop` file tells your graphical environment how to launch an application. Create one at `~/.local/share/applications/csvlens.desktop`:
 
 ```bash
 nano ~/.local/share/applications/csvlens.desktop
 ```
 
-Now, paste the following content into the file. **Crucially, replace `/home/yourusername/.cargo/bin/csvlens` with the actual path you found in Step 1.**
+Paste the following, replacing `/home/yourusername/.cargo/bin/csvlens` with the path from the previous step:
 
 ```ini
 [Desktop Entry]
@@ -48,60 +43,73 @@ MimeType=text/csv;
 Categories=Utility;TextEditor;
 ```
 
-Let's break down that important `Exec` line:
+The `Exec` line does the actual work:
 
-  * `Exec=`: This tells the system what command to run.
-  * `gnome-terminal --`: This part specifies that the command should open in a new `gnome-terminal` window. If you use a different terminal (like `konsole`, `xfce4-terminal`, etc.), replace `gnome-terminal` with your preferred terminal's command.
-  * `/bin/bash -c "..."`: This executes a Bash command within the terminal.
-  * `**YOUR_CSVLENS_PATH** %f`: This is where your actual `csvlens` path goes. `%f` is a placeholder that your file manager automatically replaces with the full path of the CSV file you clicked.
-  * `; echo 'Press Enter to close'; read"`: This is a neat trick\! Because `csvlens` is a terminal application, the terminal would normally close immediately after `csvlens` finishes. This addition prints "Press Enter to close" and then waits for you to press a key, keeping the terminal open until you're ready.
+- `gnome-terminal --` opens the command in a new terminal window. Using a different terminal emulator (`konsole`, `xfce4-terminal`)? Swap it in here.
+- `/bin/bash -c "..."` runs a Bash command inside that terminal.
+- `csvlens %f` is the actual viewer; `%f` gets replaced with the path of whichever CSV file you clicked.
+- `; echo 'Press Enter to close'; read` keeps the terminal open after csvlens exits, instead of closing immediately.
 
------
+## How do I set csvlens as the default app for CSV files?
 
-## Step 3: Set `csvlens` as the Default for CSVs
-
-Now, let's make sure your system knows to use `csvlens.desktop` for CSV files. We'll use the `xdg-mime` command for this.
-
-First, you can check what's currently set as the default for CSVs:
+Ubuntu uses `xdg-mime` to track default applications per file type. Check what's currently set for CSVs:
 
 ```bash
 xdg-mime query default text/csv
 ```
 
-Then, set your newly created `csvlens.desktop` as the default:
+Then point it at the `.desktop` file you just created:
 
 ```bash
 xdg-mime default csvlens.desktop text/csv
 ```
 
------
+## Do I need to update the MIME database after this?
 
-## Step 4: Update Your MIME Database (Good Practice)
-
-It's a good idea to refresh your system's MIME type database to ensure the changes are picked up:
+Refresh it so the change takes effect immediately, rather than waiting for the next login:
 
 ```bash
 update-desktop-database ~/.local/share/applications/
 ```
 
------
+## How do I confirm it worked?
 
-## Step 5: Test It Out\!
+Navigate to a `.csv` file in your file manager and double-click it. A terminal window should open showing the file in csvlens. Press Enter (or any key) once you're done viewing to close it.
 
-You're all set\! Navigate to a **`.csv`** file in your file manager and double-click it. A new terminal window should pop open, displaying your CSV file beautifully with `csvlens`. Once you're done viewing, simply press **Enter** (or any key) to close the terminal.
+## How does csvlens compare to less or a GUI spreadsheet app?
 
------
+csvlens describes itself as ["like `less` but made for CSV."](https://github.com/YS-L/csvlens) That comparison holds up:
 
-## Troubleshooting Tips
+| | csvlens | less | LibreOffice Calc |
+| --- | --- | --- | --- |
+| Built for CSV (columns, delimiters) | Yes | No — generic text pager | Yes |
+| Search/filter | Regex search and filter, on rows and columns | Pattern search only, no column structure | AutoFilter and Find & Replace |
+| Row limit | None documented | None — streams the file, "does not have to read the entire input file before starting" | 1,048,576 rows per sheet |
+| Needs a GUI/desktop environment | No | No | Yes |
+| Install | `cargo install csvlens` | Typically already installed | Full office-suite install |
 
-  * **Terminal opens and closes immediately:** Double-check the `Exec` line in your `csvlens.desktop` file, especially the `echo 'Press Enter to close'; read` part. A small typo can cause this.
-  * **`csvlens` doesn't open:**
-      * Verify the `Exec` path in `csvlens.desktop` precisely matches the output of `which csvlens`.
-      * Confirm that `csvlens` runs correctly when you type `csvlens your_file.csv` directly in your terminal.
-      * Ensure there are no typos in the `MimeType` line (`MimeType=text/csv;`).
-  * **Want to revert?** You can right-click a CSV file, choose "Open With Other Application," and select your previous default. Alternatively, you can use `xdg-mime` again to set a different default:
-    ```bash
-    xdg-mime default libreoffice-calc.desktop text/csv # or your preferred spreadsheet app
-    ```
+If you just need to skim a CSV without column structure, `less` already does that. If you need charts, formulas, or heavy editing, Calc is the right tool. csvlens sits in between: fast, terminal-based, and CSV-aware without a GUI.
 
-Enjoy your new, streamlined CSV viewing experience directly from your terminal, finally giving you a robust and efficient solution for CSVs on Linux\!
+## FAQ
+
+**The terminal opens and closes immediately — what's wrong?**
+Double-check the `Exec` line in your `csvlens.desktop` file, especially the `echo 'Press Enter to close'; read` part. A small typo there is the most common cause.
+
+**csvlens doesn't open when I double-click a CSV file. What should I check?**
+Confirm the path in `Exec` matches the output of `which csvlens` exactly, and that running `csvlens your_file.csv` directly in a terminal works. Also check `MimeType=text/csv;` for typos.
+
+**How do I revert to my previous default CSV app?**
+Right-click a CSV file, choose "Open With Other Application," and pick your previous default — or set it directly with `xdg-mime`:
+
+```bash
+xdg-mime default libreoffice-calc.desktop text/csv
+```
+
+**Is csvlens still actively maintained?**
+Yes — the project has close to 4,000 GitHub stars, and its latest release (v0.15.1) shipped in January 2026.
+
+## Sources
+
+- [csvlens – GitHub](https://github.com/YS-L/csvlens)
+- [`less` man page](https://man7.org/linux/man-pages/man1/less.1.html)
+- [LibreOffice Calc – Wikipedia](https://en.wikipedia.org/wiki/LibreOffice_Calc)


### PR DESCRIPTION
## Summary

Retrofits the csvlens/Ubuntu-default-viewer post to the SEO + GEO bar, via optimize-blog. This is the oldest post on the site (2025-07-11) and predates every SEO/GEO/voice rule write-blog now enforces, so the gap was larger than the Tailscale post.

## Gaps closed

| Gap | Before | After |
| --- | ------ | ----- |
| No `lastmod` | absent | `2026-07-20` |
| Meta description over 155 chars | 184 chars | 139 chars |
| Not answer-first | Opened with generic Linux-CSV-frustration framing before saying what the post does | Opens with a 2-sentence self-contained answer, quoting csvlens' own tagline |
| Headings weren't questions | "Step 1: Find Your csvlens Executable," "Step 5: Test It Out!," etc. | Reworded as real questions, step content unchanged |
| No FAQ | "Troubleshooting Tips" was already Q&A-shaped but not formatted as one | Converted directly into `## FAQ`, plus one new sourced entry on maintenance status |
| No comparison table | n/a | Added: csvlens vs. `less` vs. LibreOffice Calc (by request — csvlens' own README invites the comparison) |
| No Sources at all | The post never cited csvlens itself | Added: csvlens' GitHub repo, the `less` man page, LibreOffice Calc |
| No focus keyword on record | Predates the keyword-capture step entirely | "how to set csvlens as the default CSV viewer on Ubuntu" + related: csvlens, xdg-mime, .desktop file, terminal CSV viewer, cargo install |
| Voice violations (by request, outside optimize-blog's normal scope) | Title contained "Seamless" (a banned AI-tell), plus "fantastic," "shines," exclamation marks, an ad-copy closing line, redundant `-----` separators | Cleaned up throughout; step-by-step instructional voice kept where it was already appropriate |

## Facts re-verified

| Claim | Prior value | Current value | Source |
| ----- | ----------- | -------------- | ------ |
| csvlens description/install | Never sourced in the original post | "like `less` but made for CSV," `cargo install csvlens` confirmed current, v0.15.1 (Jan 2026), ~3.9k stars | github.com/YS-L/csvlens |
| `less` behavior (for comparison table) | — | "does not have to read the entire input file before starting," no CSV/column awareness in its documented feature set | `man less` |
| LibreOffice Calc row limit (for comparison table) | — | 1,048,576 rows per sheet | Wikipedia, citing LibreOffice's own release notes (Tier 2 — no live official page with this exact figure could be located) |

The step-by-step commands themselves (`which`, `.desktop` file format, `xdg-mime`, `update-desktop-database`) are treated as stable, unsourced procedural content per the same convention as the Tailscale post — they're Jeremy's own setup steps, not marketing claims.

## Claims audit

A fresh subagent audit of the first comparison-table draft caught several invented specifics: a claim that csvlens handles large files without loading them fully (no such claim exists anywhere in its README — re-fetched to confirm), a claim about LibreOffice Calc's filter/regex behavior that was both unsourced and likely wrong, and an overgeneralized "preinstalled on most Linux systems" claim about `less`. All fixed below.

## Cut or rewritten during audit

- Cut: "csvlens starts up on large files without loading the whole thing" — no basis in the README. Replaced with an honest "no documented row limit," keeping the *sourced* streaming claim on `less`'s own row instead.
- Cut/replaced: "LibreOffice Calc — manual filters, no regex on cells by default" — unsourced and plausibly inaccurate (Calc's Find & Replace does support a regex option). Replaced with the neutral "AutoFilter and Find & Replace."
- Softened: "less is preinstalled on most Linux systems" → "typically already installed."
- Softened: "over 3,900 GitHub stars" (overstated precision on a rounded "3.9k") → "close to 4,000."

## Notes

- File path and `date` untouched, per the skill's hard rules.
- Used an isolated git worktree (`.worktrees/blog-optimize-csvlens`) for this run since the main working directory had unrelated in-progress work on another branch — added `.worktrees/` to `.gitignore` and pushed that as a standalone commit directly to trunk beforehand.
- Same `app/tag-data.json` drift as last time reverted from this diff — still unrelated, still worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)