### PR TITLE
Update contact email to jeremy@garrellts.com

### DIFF
--- a/data/authors/default.mdx
+++ b/data/authors/default.mdx
@@ -3,7 +3,7 @@ name: Jeremy Garrell
 avatar: /static/images/avatar.png
 occupation: Builder of Virtual Things
 company: Garrell Tech Solutions
-email: jeremy.garrell@gmail.com
+email: jeremy@garrellts.com
 linkedin: https://www.linkedin.com/in/jeremygarrell
 github: https://github.com/garrelj1
 ---
@@ -11,6 +11,7 @@ github: https://github.com/garrelj1
 Jeremy Garrell is the CEO/Founder of Garrell Tech Solutions LLC. He enjoys building things (both physically and virtually), learning about history and studying Chabad Chassidus (Jewish Philosophy) and Halacha (Jewish Law)
 
 He has expertise in a wide variety of software development domains:
+
 - Android application development
 - Full stack web development
 - Enterprise data ingest pipelines

--- a/data/authors/jeremy.mdx
+++ b/data/authors/jeremy.mdx
@@ -3,7 +3,7 @@ name: Jeremy Garrell
 avatar: /static/images/avatar.png
 occupation: Builder of Virtual Things
 company: Garrell Tech Solutions
-email: jeremy.garrell@gmail.com
+email: jeremy@garrellts.com
 linkedin: https://www.linkedin.com/in/jeremygarrell
 github: https://github.com/garrelj1
 ---
@@ -11,6 +11,7 @@ github: https://github.com/garrelj1
 Jeremy Garrell is the CEO/Founder of Garrell Tech Solutions LLC. He enjoys building things (both physically and virtually), learning about history and studying Chabad Chassidus (Jewish Philosophy) and Halacha (Jewish Law)
 
 He has expertise in a wide variety of software development domains:
+
 - Android application development
 - Full stack web development
 - Enterprise data ingest pipelines

--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -10,7 +10,7 @@ const siteMetadata = {
   siteRepo: 'https://github.com/garrelj1/garrell-tech-solutions',
   siteLogo: `${process.env.BASE_PATH || ''}/static/images/logo.png`,
   socialBanner: `${process.env.BASE_PATH || ''}/static/images/twitter-card.png`,
-  email: 'jeremy.garrell@gmail.com',
+  email: 'jeremy@garrellts.com',
   github: 'https://github.com/garrelj1',
   x: 'https://twitter.com/x',
   // twitter: 'https://twitter.com/Twitter',


### PR DESCRIPTION
Replaces the old `jeremy.garrell@gmail.com` address with the `jeremy@garrellts.com` domain address across the site.

## Files changed
- `data/siteMetadata.js` — site-wide metadata email
- `data/authors/jeremy.mdx` — author profile
- `data/authors/default.mdx` — default author profile

The landing page (`app/page.tsx`) already used the new address, so no change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)