### PR TITLE
Add the two disclosures /sms-terms was missing

### DIFF
--- a/app/sms-terms/page.tsx
+++ b/app/sms-terms/page.tsx
@@ -47,6 +47,20 @@ export default function Page() {
         <h2>Cost</h2>
         <p>Message and data rates may apply.</p>
 
+        <h2>No sharing for marketing</h2>
+        <p>
+          No mobile information will be shared with third parties or affiliates for marketing or
+          promotional purposes. Information sharing to subcontractors for support services (e.g.,
+          customer service) is permitted. All other categories exclude text messaging originator
+          opt-in data and consent from being shared with any third parties.
+        </p>
+
+        <h2>Privacy</h2>
+        <p>
+          How we handle enrolled phone numbers is described in our{' '}
+          <a href="/sms-privacy">SMS Privacy Policy</a>.
+        </p>
+
         <h2>Opting out</h2>
         <p>
           Reply <strong>STOP</strong> at any time to opt out of this program.


### PR DESCRIPTION
## Why

Filing the A2P 10DLC campaign registration today. The Console's terms-and-conditions URL field is checked independently of the privacy policy field, and reviewers expect the full disclosure set on each page rather than split across the two.

Checked `/sms-terms` live before filing. It had:

- brand name — "Garrell Tech Solutions' inquiry notification SMS service"
- message frequency — "one message per inquiry, not a fixed number per month"
- "Message and data rates may apply."
- STOP and HELP instructions

It was missing:

- **a non-sharing statement for mobile numbers**
- **a link to the privacy policy**

`/sms-privacy` has both. The non-sharing statement in particular is the element Twilio's own support agent named as missing during the second round of campaign feedback (see `laundromat-site-template` `docs/a2p-consent.md` §5b), so it is not a hypothetical omission — it is one that has already cost a round.

## What changed

Two new sections on `app/sms-terms/page.tsx`, placed after **Cost** and before **Opting out** so the page mirrors `/sms-privacy`'s ordering:

- **No sharing for marketing** — copied **verbatim** from `/sms-privacy` rather than reworded, so the two pages cannot drift into saying different things about the same practice. Keeps the canonical carrier-accepted phrasing intact.
- **Privacy** — links to `/sms-privacy`.

## Notes

- **Effective date left at August 4, 2026.** These are additive disclosures of existing practice, not a change to any obligation. A fresh effective date on a page a carrier is about to review invites a "what changed?" question with no interesting answer. Say the word if you'd rather bump it.
- No copy elsewhere on the page touched; the word "lead" still appears nowhere, so the PR #22 terminology sweep is unaffected.
- **Deploy path worth confirming:** `.github/workflows/pages.yml` triggers on push to `main`, but `main` here is the untouched upstream template branch (74 commits behind `trunk`, no `app/sms-terms` at all). So that workflow does not deploy this. The live site is presumably built from `trunk` by a dashboard-connected host. **Confirm `/sms-terms` actually shows the new sections before pasting the URL into the campaign form.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)