### PR TITLE
Publish agent architecture standards as an LLM-retrievable doc

### DIFF
--- a/app/docs/[slug]/page.tsx
+++ b/app/docs/[slug]/page.tsx
@@ -1,0 +1,119 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import PageTitle from '@/components/PageTitle'
+import siteMetadata from '@/data/siteMetadata'
+import { docMarkdownPath, docMarkdownUrl, docUpdated, docUrl, getDoc, publishedDocs } from '../docs'
+
+export async function generateStaticParams() {
+  return publishedDocs.map((doc) => ({ slug: doc.slug }))
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata | undefined> {
+  const { slug } = await props.params
+  const doc = getDoc(slug)
+
+  if (!doc) {
+    return
+  }
+
+  return {
+    title: doc.title,
+    description: doc.summary,
+    alternates: {
+      canonical: docUrl(doc.slug),
+      // Advertises the raw markdown twin to crawlers and retrieval agents.
+      types: {
+        'text/markdown': docMarkdownUrl(doc.slug),
+      },
+    },
+    openGraph: {
+      title: doc.title,
+      description: doc.summary,
+      siteName: siteMetadata.title,
+      locale: 'en_US',
+      type: 'article',
+      url: docUrl(doc.slug),
+      images: [siteMetadata.socialBanner],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: doc.title,
+      description: doc.summary,
+      images: [siteMetadata.socialBanner],
+    },
+  }
+}
+
+export default async function Page(props: { params: Promise<{ slug: string }> }) {
+  const { slug } = await props.params
+  const doc = getDoc(slug)
+
+  if (!doc) {
+    return notFound()
+  }
+
+  const updated = docUpdated(doc)
+  const rawHref = `${process.env.BASE_PATH || ''}${docMarkdownPath(doc.slug)}`
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: doc.title,
+    description: doc.summary,
+    datePublished: doc.date,
+    dateModified: doc.lastmod || doc.date,
+    url: docUrl(doc.slug),
+    inLanguage: siteMetadata.locale,
+    author: { '@type': 'Organization', name: siteMetadata.headerTitle },
+    publisher: { '@type': 'Organization', name: siteMetadata.headerTitle },
+    encoding: {
+      '@type': 'MediaObject',
+      encodingFormat: 'text/markdown',
+      contentUrl: docMarkdownUrl(doc.slug),
+    },
+  }
+
+  return (
+    <div className="divide-y divide-gray-200 dark:divide-gray-700">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <div className="space-y-2 pt-6 pb-8 md:space-y-5">
+        <PageTitle>{doc.title}</PageTitle>
+        {doc.summary && (
+          <p className="text-lg leading-7 text-gray-500 dark:text-gray-400">{doc.summary}</p>
+        )}
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Last updated{' '}
+          <time dateTime={updated} suppressHydrationWarning>
+            {updated}
+          </time>{' '}
+          &middot;{' '}
+          <a
+            href={rawHref}
+            className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+          >
+            Raw markdown
+          </a>
+        </p>
+      </div>
+      <div className="prose dark:prose-invert max-w-none py-12">
+        <div dangerouslySetInnerHTML={{ __html: doc.body.html }} />
+      </div>
+      <div className="pt-6 text-sm text-gray-500 dark:text-gray-400">
+        <p>
+          Machine-readable copy of this document:{' '}
+          <a
+            href={rawHref}
+            className="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400"
+          >
+            {docMarkdownUrl(doc.slug)}
+          </a>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/docs/agent-architecture.md/route.ts
+++ b/app/docs/agent-architecture.md/route.ts
@@ -1,0 +1,23 @@
+import { getDoc, renderDocMarkdown } from '../docs'
+
+export const dynamic = 'force-static'
+
+const SLUG = 'agent-architecture'
+
+export async function GET() {
+  const doc = getDoc(SLUG)
+
+  if (!doc) {
+    return new Response('Not found\n', {
+      status: 404,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+  }
+
+  return new Response(renderDocMarkdown(doc), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+    },
+  })
+}

--- a/app/docs/docs.ts
+++ b/app/docs/docs.ts
@@ -1,0 +1,56 @@
+import { allDocs, type Doc } from 'contentlayer/generated'
+import siteMetadata from '@/data/siteMetadata'
+
+/** Docs that should be published. Drafts are excluded from every route. */
+export const publishedDocs = allDocs.filter((doc) => !doc.draft)
+
+export function getDoc(slug: string): Doc | undefined {
+  return publishedDocs.find((doc) => doc.slug === slug)
+}
+
+export function docPath(slug: string) {
+  return `/docs/${slug}`
+}
+
+export function docMarkdownPath(slug: string) {
+  return `/docs/${slug}.md`
+}
+
+export function docUrl(slug: string) {
+  return `${siteMetadata.siteUrl}${docPath(slug)}`
+}
+
+export function docMarkdownUrl(slug: string) {
+  return `${siteMetadata.siteUrl}${docMarkdownPath(slug)}`
+}
+
+export function docUpdated(doc: Doc) {
+  return (doc.lastmod || doc.date).split('T')[0]
+}
+
+/**
+ * The payload served at /docs/<slug>.md.
+ *
+ * The frontmatter is regenerated rather than passed through so that a retrieval
+ * client gets the canonical URL, publisher, and update date alongside the body,
+ * without depending on whatever keys the source file happens to carry.
+ */
+export function renderDocMarkdown(doc: Doc): string {
+  const frontmatter: [string, string][] = [
+    ['title', doc.title],
+    ['description', doc.summary || ''],
+    ['publisher', siteMetadata.headerTitle],
+    ['source', docUrl(doc.slug)],
+    ['markdown_source', docMarkdownUrl(doc.slug)],
+    ['updated', docUpdated(doc)],
+  ]
+
+  const yaml = frontmatter
+    .filter(([, value]) => value)
+    // JSON string escaping is valid YAML double-quoted scalar syntax, so this
+    // stays correct for titles and summaries containing colons or quotes.
+    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+    .join('\n')
+
+  return `---\n${yaml}\n---\n\n# ${doc.title}\n\n${doc.body.raw.trim()}\n`
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,48 @@
+import { allBlogs } from 'contentlayer/generated'
+import { sortPosts } from 'pliny/utils/contentlayer'
+import siteMetadata from '@/data/siteMetadata'
+import { docMarkdownUrl, publishedDocs } from '../docs/docs'
+
+export const dynamic = 'force-static'
+
+/**
+ * https://llmstxt.org convention: a single plain-text index that points a
+ * retrieval agent at the markdown copies of this site's content.
+ */
+export async function GET() {
+  const docs = publishedDocs
+    .map((doc) => `- [${doc.title}](${docMarkdownUrl(doc.slug)}): ${doc.summary || ''}`.trim())
+    .join('\n')
+
+  const posts = sortPosts(allBlogs.filter((post) => !post.draft))
+    .map((post) =>
+      `- [${post.title}](${siteMetadata.siteUrl}/${post.path}): ${post.summary || ''}`.trim()
+    )
+    .join('\n')
+
+  const body = `# ${siteMetadata.headerTitle}
+
+> ${siteMetadata.description}. Custom software, systems architecture, and automation work by ${siteMetadata.author}.
+
+## Standards and architecture documents
+
+${docs}
+
+## Blog
+
+${posts}
+
+## Pages
+
+- [About](${siteMetadata.siteUrl}/about): Who Garrell Tech Solutions is and what it builds.
+- [Projects](${siteMetadata.siteUrl}/projects): Selected work.
+- [Contact](mailto:${siteMetadata.email}): Email ${siteMetadata.author}.
+`
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+    },
+  })
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from 'next'
 import { allBlogs } from 'contentlayer/generated'
 import siteMetadata from '@/data/siteMetadata'
+import { docMarkdownUrl, docUpdated, docUrl, publishedDocs } from './docs/docs'
 
 export const dynamic = 'force-static'
 
@@ -14,10 +15,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: post.lastmod || post.date,
     }))
 
+  // Both the HTML page and its raw markdown twin are listed, so crawlers that
+  // prefer markdown can find it without guessing the URL.
+  const docRoutes = publishedDocs.flatMap((doc) => [
+    { url: docUrl(doc.slug), lastModified: docUpdated(doc) },
+    { url: docMarkdownUrl(doc.slug), lastModified: docUpdated(doc) },
+  ])
+
   const routes = ['', 'blog', 'projects', 'tags'].map((route) => ({
     url: `${siteUrl}/${route}`,
     lastModified: new Date().toISOString().split('T')[0],
   }))
 
-  return [...routes, ...blogRoutes]
+  return [...routes, ...docRoutes, ...blogRoutes]
 }

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -147,9 +147,52 @@ export const Authors = defineDocumentType(() => ({
   computedFields,
 }))
 
+export const Doc = defineDocumentType(() => ({
+  name: 'Doc',
+  filePathPattern: 'docs/**/*.md',
+  contentType: 'markdown',
+  fields: {
+    title: { type: 'string', required: true },
+    summary: { type: 'string' },
+    date: { type: 'date', required: true },
+    lastmod: { type: 'date' },
+    draft: { type: 'boolean' },
+  },
+  computedFields: {
+    slug: {
+      type: 'string',
+      resolve: (doc) => doc._raw.flattenedPath.replace(/^docs\//, ''),
+    },
+    path: {
+      type: 'string',
+      resolve: (doc) => doc._raw.flattenedPath,
+    },
+    filePath: {
+      type: 'string',
+      resolve: (doc) => doc._raw.sourceFilePath,
+    },
+  },
+}))
+
 export default makeSource({
   contentDirPath: 'data',
-  documentTypes: [Blog, Authors],
+  documentTypes: [Blog, Authors, Doc],
+  markdown: {
+    remarkPlugins: [remarkGfm],
+    rehypePlugins: [
+      rehypeSlug,
+      [
+        rehypeAutolinkHeadings,
+        {
+          behavior: 'prepend',
+          headingProperties: {
+            className: ['content-header'],
+          },
+          content: icon,
+        },
+      ],
+    ],
+  },
   mdx: {
     cwd: process.cwd(),
     remarkPlugins: [

--- a/data/docs/agent-architecture.md
+++ b/data/docs/agent-architecture.md
@@ -1,0 +1,54 @@
+---
+title: Agent Architecture Standards
+summary: The architectural standards Garrell Tech Solutions applies to every codebase, written for retrieval by coding agents. Starts with abstracted set operations.
+date: '2026-08-21'
+lastmod: '2026-08-21'
+---
+
+## Scope
+
+These standards apply to every service, application, and automation Garrell Tech Solutions builds or maintains. They bind human contributors and AI coding agents equally.
+
+An agent working in a Garrell Tech Solutions repository should treat each standard below as a hard constraint on the code it produces, and should reject or revise a plan that violates one rather than implementing it.
+
+## Standard: Abstracted Set Operations
+
+### 1. Principle: separation of intention from execution
+
+When dealing with large collections of entities, the definition of how data should be ordered, filtered, or paginated is a business rule. However, the execution of those operations must occur at the persistence layer for performance and memory efficiency.
+
+To satisfy both Clean Architecture boundaries and systemic performance requirements, systems must strictly separate the **Intention** (Domain) from the **Execution** (Infrastructure).
+
+### 2. The pattern: domain specifications
+
+The system must never fetch bulk, unoptimized datasets into application memory to perform sorting, filtering, or pagination. Instead, it must use the Specification (or Criteria) pattern to push these operations down to the storage mechanism without leaking storage-specific syntax into the core application.
+
+| Layer          | Owns                                                                 | Must not                                          |
+| -------------- | -------------------------------------------------------------------- | ------------------------------------------------- |
+| Domain         | The rules of precedence, filtering boundaries, and pagination limits | Know anything about the storage mechanism         |
+| Application    | Assembly of specifications and the call across the output port       | Re-sort, re-filter, or paginate results in memory |
+| Infrastructure | Translation of a specification into native storage operations        | Leak storage concepts back across the port        |
+
+#### The Domain layer (intention)
+
+- **Responsibility:** Defines the rules of precedence, filtering boundaries, and pagination limits using pure business concepts.
+- **Implementation:** Exposes abstract value objects or data structures, such as `SortSpecification` or `FilterCriteria`.
+- **Constraint:** These objects must describe what is desired in domain terminology, for example "sort by task urgency". They must be entirely ignorant of the underlying storage mechanism.
+
+#### The Application layer (orchestration)
+
+- **Responsibility:** Coordinates the workflow by assembling the domain specifications based on the input request.
+- **Implementation:** Passes the specification objects through an output port (an interface).
+- **Constraint:** The application layer must trust that the port returns the data pre-sorted and pre-filtered according to the specification. It must not attempt to re-sort or manually paginate the returned collection in memory.
+
+#### The Infrastructure layer (execution)
+
+- **Responsibility:** Interacts with the actual storage medium, such as a relational data store, flat CSV files, or an external API.
+- **Implementation:** Implements the output port. It receives the pure domain specification and translates it into the native syntax or operational logic the storage medium requires.
+- **Constraint:** This is the only layer permitted to know how a domain concept maps to a storage concept, for example translating "task urgency" into a specific column index, a file parsing routine, or an API query parameter.
+
+### 3. Strict invariants
+
+1. **No storage syntax in the core.** The domain and application layers must never contain query language strings, file traversal logic, or storage-specific data types.
+2. **No in-memory bulk operations.** The application layer must never load an entire collection into memory to perform slicing or reordering that the underlying persistence mechanism can handle natively.
+3. **Opaque data retrieval.** The mechanism of retrieval must remain completely opaque to the application layer. The application must not know whether the sorting was achieved by a highly optimized indexing engine or by linearly scanning flat text files.


### PR DESCRIPTION
## What

Publishes the Garrell Tech Solutions agent architecture standards at two URLs:

| URL | Serves |
| --- | --- |
| `/docs/agent-architecture` | HTML page with site chrome, prose styling, and TechArticle JSON-LD |
| `/docs/agent-architecture.md` | Raw markdown, `Content-Type: text/markdown; charset=utf-8` |

Initial content is the **Abstracted Set Operations** standard: the domain defines sort, filter, and pagination intent as specifications; infrastructure translates them into native storage operations; the application layer never loads a bulk collection into memory to reorder or slice it.

## How it is optimized for LLM retrieval

- **A distinct `.md` URL.** The site exports statically, so content negotiation is not available. A separate extension is what gets the right MIME type from the host and what retrieval crawlers actually follow.
- **Regenerated frontmatter.** The `.md` route rebuilds the frontmatter (`title`, `description`, `publisher`, `source`, `markdown_source`, `updated`) instead of passing the source file through, so a client always receives the canonical URL and update date regardless of what keys the source file carries.
- **Discoverability.** The HTML page carries `rel="alternate" type="text/markdown"`, a canonical tag, and a visible link. `/llms.txt` (the llmstxt.org convention) indexes the doc, every blog post, and key pages. The sitemap lists both the page and the `.md` file.

## Structure

A new `Doc` contentlayer type reads `data/docs/*.md`, so adding the next standard is one markdown file plus a three-line route for its `.md` twin.

## Verification

`EXPORT=1 UNOPTIMIZED=1 yarn build` from a clean worktree off `trunk`. The export produces `out/docs/agent-architecture.html`, `out/docs/agent-architecture.md`, `out/llms.txt`, and sitemap entries for both doc URLs.

## Notes

- The doc page currently has no inbound internal link (only the sitemap and `/llms.txt`). Happy to add a `/docs` index and a header nav entry in a follow-up if you want crawlers to weight it more heavily.
- Unrelated: `trunk`'s checked-in `app/tag-data.json` is stale relative to its own blog content; the build regenerates five missing tags. Left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)